### PR TITLE
Fixing issue: POST route returns 405 if 'ep_etherpad-lite/static' is loaded before plugin.

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -2,6 +2,7 @@
   "parts": [
     {
       "name": "post_data",
+      "post": ["ep_etherpad-lite/static"],
       "hooks": {
         "expressCreateServer": "ep_post_data/index:registerRoute"
       }


### PR DESCRIPTION
Same issue of https://github.com/JohnMcLear/ep_comments/issues/41